### PR TITLE
Move exports around to expose functions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-lazy val root = project.enablePlugins(ScalaJSPlugin)
-
 lazy val client = project
   .in(file("scala-js"))
   .enablePlugins(ScalaJSPlugin)
@@ -12,5 +10,5 @@ lazy val client = project
     )
   )
   .settings(
-    scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
+    scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.ESModule) }
   )

--- a/scala-js/src/main/scala/com/jisantuc/fphttp/client.scala
+++ b/scala-js/src/main/scala/com/jisantuc/fphttp/client.scala
@@ -13,24 +13,23 @@ import io.circe.ParsingFailure
 import java.net.URI
 import java.util.UUID
 import scala.scalajs.js.annotation.JSExportTopLevel
-import scala.scalajs.js.annotation.JSExport
+import java.nio.charset.StandardCharsets
 
-@JSExportTopLevel("STAC")
 object client {
   val client = basicRequest
   implicit val ec = scala.concurrent.ExecutionContext.Implicits.global
   implicit val backend = FetchBackend()
 
-  @JSExport("getCollection")
-  def getCollection(collectionId: UUID): Future[StacCollection] =
+  @JSExportTopLevel("collection")
+  def collection(collectionId: String): Future[StacCollection] =
     client
-      .get(uri"http://localhost:9090/collections/${collectionId}")
+      .get(uri"http://localhost:9090/collections/$collectionId")
       .response(asJson[StacCollection])
       .send()
       .decode
 
-  @JSExport("getCollections")
-  def getCollections: Future[List[StacCollection]] =
+  @JSExportTopLevel("collections")
+  def collections(): Future[List[StacCollection]] =
     client
       .get(Uri(URI.create("http://localhost:9090/collections")))
       .response(asJson[List[StacCollection]])

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,13 +7,12 @@ import { useAsync, useMeasure } from "react-use";
 import LoadingIcon from "components/LoadingIcon";
 import { ViewportProps } from "react-map-gl";
 import Map from "components/Map";
-import { STAC } from "./stac.js";
+import { collection, collections } from "./stac.js";
 
 const App: React.FC = () => {
-  // const collections = STAC.getCollections();
-  // console.log(collections);
-  console.log(STAC);
-  const collection = {
+  collections();
+  collection("doesnt-exist");
+  const collectionC = {
     stac_version: "0.9.0",
     stac_extensions: ["label"],
     id: "berlin",
@@ -55,8 +54,8 @@ const App: React.FC = () => {
       },
     ],
   };
-  const { value, error, loading } = useAsync<typeof collection>(async () => {
-    const result = await Promise.resolve(collection);
+  const { value, error, loading } = useAsync<typeof collectionC>(async () => {
+    const result = await Promise.resolve(collectionC);
     return result;
   });
 


### PR DESCRIPTION
This PR moves the top level export from the `client` object onto the functions I wanted exported. This makes it
so that, as you can see in `App.tsx`, you can `import { collection, collections } from "./stac.js". It will take some work to get the typescript types going, but I can probably overload `panrec` for that (I hope) since [`sbt-scalajs-ts-export`](https://github.com/waveinch/sbt-scalajs-ts-export) looks pretty dead.

Closes #5