### PR TITLE
Add STAC types

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -107,4 +107,23 @@ in  upstream
 let upstream =
       https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20210118/packages.dhall sha256:a59c5c93a68d5d066f3815a89f398bcf00e130a51cb185b2da29b20e2d8ae115
 
-in  upstream
+let overrides =
+      { test-unit =
+        { dependencies =
+          [ "aff"
+          , "either"
+          , "prelude"
+          , "effect"
+          , "quickcheck"
+          , "free"
+          , "strings"
+          , "lists"
+          , "js-timers"
+          , "avar"
+          ]
+        , repo = "https://github.com/milesfrain/purescript-test-unit.git"
+        , version = "stackless-default"
+        }
+      }
+
+in  upstream // overrides

--- a/spago.dhall
+++ b/spago.dhall
@@ -2,7 +2,7 @@
 Welcome to a Spago project!
 You can edit this file as you like.
 -}
-{ name = "my-project"
+{ name = "ps-stac"
 , dependencies = [ "console"
                  , "effect"
                  , "psci-support"

--- a/spago.dhall
+++ b/spago.dhall
@@ -3,7 +3,13 @@ Welcome to a Spago project!
 You can edit this file as you like.
 -}
 { name = "my-project"
-, dependencies = [ "console", "effect", "psci-support", "affjax", "argonaut" ]
+, dependencies = [ "console"
+                 , "effect"
+                 , "psci-support"
+                 , "affjax"
+                 , "argonaut"
+                 , "datetime" 
+                 , "refined" ]
 , packages = ./packages.dhall
 , sources = [ "src-ps/**/*.purs", "test-ps/**/*.purs" ]
 }

--- a/spago.dhall
+++ b/spago.dhall
@@ -9,7 +9,8 @@ You can edit this file as you like.
                  , "affjax"
                  , "argonaut"
                  , "datetime" 
-                 , "refined" ]
+                 , "refined"
+                 , "test-unit" ]
 , packages = ./packages.dhall
 , sources = [ "src-ps/**/*.purs", "test-ps/**/*.purs" ]
 }

--- a/src-ps/Codec.purs
+++ b/src-ps/Codec.purs
@@ -1,0 +1,4 @@
+module Codec where
+  
+foo :: Int
+foo = 3

--- a/src-ps/Main.purs
+++ b/src-ps/Main.purs
@@ -1,10 +1,8 @@
 module Main where
 
-import Data.Show (show)
 import Data.Unit (Unit)
 import Effect (Effect)
 import Effect.Console as Console
-import Model (extent)
 
 main :: Effect Unit
-main = Console.log (show extent)
+main = Console.log "hi there 🌊"

--- a/src-ps/Main.purs
+++ b/src-ps/Main.purs
@@ -1,8 +1,10 @@
 module Main where
 
+import Data.Show (show)
 import Data.Unit (Unit)
 import Effect (Effect)
 import Effect.Console as Console
+import Model (extent)
 
 main :: Effect Unit
-main = Console.log "yeah man"
+main = Console.log (show extent)

--- a/src-ps/Model.purs
+++ b/src-ps/Model.purs
@@ -1,0 +1,113 @@
+module Model where
+
+import Data.Argonaut (Json)
+import Data.Date (Month(..))
+import Data.DateTime (DateTime(..), Time(..), canonicalDate)
+import Data.Either (Either(..))
+import Data.Enum (toEnum)
+import Data.Maybe (Maybe(..))
+import Data.Refined (Refined, RefinedError(..), SizeEqualTo, refine)
+import Data.Refined.Predicate (class Predicate)
+import Data.Typelevel.Num (D4)
+import Prelude ((<$>), (<*>))
+
+-- predicate requiring at least one non-Nothing item in a list of two items
+-- implies SizeEqualTo D2, but I don't know how to tell the compiler that
+data OneOrBoth a
+
+instance predicateOneOrBoth :: Predicate (OneOrBoth p) (Array (Maybe x)) where
+  validate _ arr =
+    case arr of
+      [Just _, _] -> Right arr
+      [_, Just _] -> Right arr
+      _ -> Left NotError
+
+data StacProviderRole =
+  Licensor
+  | Producer
+  | Processor
+  | Host
+
+type TwoDimBbox = Refined (SizeEqualTo D4) (Array Number)
+
+type SpatialExtent = {
+    bbox :: Array TwoDimBbox
+}
+
+type TemporalExtent = Refined (OneOrBoth DateTime) (Array (Maybe DateTime))
+
+aDateTime :: Maybe DateTime
+aDateTime = 
+  let
+    date = canonicalDate <$> toEnum 2021 <*> Just January <*> toEnum 1
+    time = Time <$> toEnum 0 <*> toEnum 0 <*> toEnum 0 <*> toEnum 0
+  in
+     DateTime <$> date <*> time
+
+extent :: Either (RefinedError (Array (Maybe DateTime))) TemporalExtent
+extent = refine [Nothing, aDateTime]
+
+type Interval = {
+    interval :: Array TemporalExtent
+}
+
+type StacExtent = {
+    spatial :: SpatialExtent,
+    temporal :: Interval
+}
+
+type StacProvider = {
+    name :: String,
+    description :: Maybe String,
+    roles :: Array StacProviderRole,
+    url :: Maybe String
+}
+
+data StacLinkType =
+  Self                                   
+  | StacRoot                               
+  | Parent                                 
+  | Child                                  
+  | Item                                   
+  | Items                                  
+  | Source                                 
+  | Collection                             
+  | License                                
+  | Alternate                              
+  | DescribedBy                            
+  | Next                                   
+  | Prev                                   
+  | ServiceDesc                            
+  | ServiceDoc                             
+  | Conformance                            
+  | Data                                   
+  | LatestVersion                          
+  | PredecessorVersion                     
+  | SuccessorVersion                       
+  | DerivedFrom                            
+  | VendorLinkType String
+
+type StacLink = {
+  href :: String,
+  rel :: StacLinkType,
+  _type :: Maybe String,
+  title :: Maybe String,
+  extensionFields :: Json
+}
+
+type StacCollection = {
+    stacVersion :: String,
+    stacExtensions :: Array String,
+    id :: String,
+    title :: Maybe String,
+    description :: String,
+    keywords :: Array String,
+    license :: String,
+    providers :: Array StacProvider,
+    extent :: StacExtent,
+    summaries :: Json,
+    properties :: Json,
+    links :: Array StacLink,
+    extensionFields :: Json
+}
+

--- a/src-ps/Model.purs
+++ b/src-ps/Model.purs
@@ -6,7 +6,7 @@ import Data.DateTime (DateTime(..), Time(..), canonicalDate)
 import Data.Either (Either(..))
 import Data.Enum (toEnum)
 import Data.Maybe (Maybe(..))
-import Data.Refined (Refined, RefinedError(..), SizeEqualTo, refine)
+import Data.Refined (Refined, RefinedError(..), SizeEqualTo)
 import Data.Refined.Predicate (class Predicate)
 import Data.Typelevel.Num (D4)
 import Prelude ((<$>), (<*>))
@@ -43,9 +43,6 @@ aDateTime =
     time = Time <$> toEnum 0 <*> toEnum 0 <*> toEnum 0 <*> toEnum 0
   in
      DateTime <$> date <*> time
-
-extent :: Either (RefinedError (Array (Maybe DateTime))) TemporalExtent
-extent = refine [Nothing, aDateTime]
 
 type Interval = {
     interval :: Array TemporalExtent

--- a/src-ps/Stac.purs
+++ b/src-ps/Stac.purs
@@ -1,0 +1,17 @@
+module Stac where
+
+import Affjax (Error, defaultRequest)
+import Affjax as AX
+import Affjax.ResponseFormat as ResponseFormat
+import Data.Either (Either)
+import Data.Typelevel.Undefined (undefined)
+import Effect.Aff (Aff)
+import Model (StacCollection)
+import Prelude (bind, pure, ($), (<>))
+
+getCollections :: String -> Aff (Either Error (Array StacCollection))
+getCollections apiHost = do
+  resp <- AX.request $
+          defaultRequest { url = apiHost <> "/collections", responseFormat = ResponseFormat.json }
+  -- pure $ toStacCollection resp.body
+  undefined

--- a/test-ps/Main.purs
+++ b/test-ps/Main.purs
@@ -2,10 +2,44 @@ module Test.Main where
 
 import Prelude
 
+import Data.Date (Month(..))
+import Data.DateTime (DateTime(..), Time(..), canonicalDate)
+import Data.Either (Either)
+import Data.Either as Either
+import Data.Enum (toEnum)
+import Data.Maybe (Maybe(..))
+import Data.Refined (RefinedError, refine)
 import Effect (Effect)
-import Effect.Class.Console (log)
+import Model (TemporalExtent)
+import Test.Unit (suite, test)
+import Test.Unit.Assert as Assert
+import Test.Unit.Main (runTest)
 
 main :: Effect Unit
 main = do
-  log "🍝"
-  log "You should add some tests."
+  runTest do
+    suite "Temporal extent refinement" do
+      test "Two nothings -- not ok" $
+        Assert.assert "" $ Either.isLeft (refineTemporalExtent [Nothing, Nothing])
+      test "Less than two items even if a Just -- not ok" $
+        Assert.assert "" $ Either.isLeft (refineTemporalExtent [dateTime])
+      test "More than two items even if a Just -- not ok" $
+        Assert.assert "" $ Either.isLeft (refineTemporalExtent [dateTime, dateTime, dateTime])
+      test "Two items, both Just -- ok" $
+        Assert.assert "" $ Either.isRight (refineTemporalExtent [dateTime, dateTime])
+      test "Two items, Just in front -- ok" $
+        Assert.assert "" $ Either.isRight (refineTemporalExtent [dateTime, Nothing])
+      test "Two items, Just in back -- ok" $
+        Assert.assert "" $ Either.isRight (refineTemporalExtent [Nothing, dateTime])
+
+
+refineTemporalExtent :: Array (Maybe DateTime) -> Either (RefinedError (Array (Maybe DateTime))) TemporalExtent
+refineTemporalExtent = refine
+
+dateTime :: Maybe DateTime
+dateTime =
+  let
+    date = canonicalDate <$> toEnum 2021 <*> Just January <*> toEnum 1
+    time = Time <$> toEnum 0 <*> toEnum 0 <*> toEnum 0 <*> toEnum 0
+  in
+     DateTime <$> date <*> time


### PR DESCRIPTION
Overview
-----

This PR adds:

- a purescript project to hold STAC things
- STAC types for links, provider roles, collections, extents, etc.
- refinement (wow this was uh surprisingly ok) so bboxes have the right length, temporal extents have at least one non-maybe, etc.
-  a `Stac.purs` module that will eventually make and decode API calls for STAC collections

There's nothing too fancy going on here yet.

Testing
-----

- `nvm use`
- `npm install -g purescript`
- `npm install -g spago`
- `spago test` -- you should see some successful tests proving the temporal extent refinement Just Works :tm: