### PR TITLE
Use built-in lmap from bifunctor

### DIFF
--- a/src-ps/Codec.purs
+++ b/src-ps/Codec.purs
@@ -1,8 +1,1 @@
 module Codec where
-
-import Data.Either (Either(..))
-
-leftMap :: forall e a b. (e -> b) -> Either e a -> Either b a
-leftMap f (Right r) = Right r
-
-leftMap f (Left e) = Left (f e)

--- a/src-ps/JsonDate.purs
+++ b/src-ps/JsonDate.purs
@@ -1,9 +1,9 @@
 module JsonDate (JsonDate(..), fromString) where
 
 import Data.Formatter.DateTime
-import Codec (leftMap)
 import Data.Argonaut (class DecodeJson, JsonDecodeError(..), toString)
 import Data.Array (foldl, snoc, uncons)
+import Data.Bifunctor (lmap)
 import Data.DateTime (DateTime)
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
@@ -37,5 +37,5 @@ fromString s = JsonDate <$> (unformatDateTime "YYYY-MM-DDTHH:mm:SS" <<< dropTz) 
 
 instance decodeJsonDate :: DecodeJson JsonDate where
   decodeJson js = case toString js of
-    Just s -> leftMap adaptParseError $ fromString s
+    Just s -> lmap adaptParseError $ fromString s
     Nothing -> Left $ TypeMismatch "Expected a JSON string"


### PR DESCRIPTION
Overview
-----

`Data.Bifunctor` already contains an `lmap` function. It's totally unncessary to implement an `Either`-specific version in `Codec.purs`. This PR subs out that implementation for the function in `Data.Bifunctor`.